### PR TITLE
Catch error caused by missing style files

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ style.prototype.info = function(callback) {
 
     return async.map(data.styles, function(filename, next) {
       return fs.readFile(path.join(path.dirname(fname), filename), "utf8", function(err, mss) {
-        return next(null, [filename, mss]);
+        return next(err, [filename, mss]);
       });
     }, function(err, styles) {
       if (err) {


### PR DESCRIPTION
Previously, the error returned by a failed style (mss) file read
was ignored. This caused errors down the line, which were harder to track
down.
