### PR TITLE
Close backend sources after reading info from them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## v0.5.0 - 2/16/16
+
+* Close backend source (before `tilelive-cache@0.6.0` this will result in closed
+  (unusable) sources being loaded)
+
 ## v0.4.2 - 10/28/15
 
 * Remove unnecessary key sorting when generating Mapnik XML

--- a/index.js
+++ b/index.js
@@ -183,6 +183,12 @@ style.toXML = function(data, callback) {
         };
       });
 
+      // close the backend source if possible
+      if (backend.close) {
+        // some close() implementations require a callback
+        backend.close(function() {});
+      }
+
       try {
         return callback(null, new carto.Renderer().render(opts));
       } catch (err) {


### PR DESCRIPTION
This has caching implications when used with `tilelive-cache`, as sources aren't removed from cache when closed. I need to add corresponding code there to prevent this from causing problems.

Refs #4 

/cc @StevenLooman
